### PR TITLE
OC-1146 - add showOnlyFails option

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ newman run <collection-url> --environment=<env-url> -r @decathlon/pullrequest-de
 `--reporter-pullrequest-decorator-refcommit` | (Required) Long Commit hash. When you run this reporter from a Pull Request. You should use : ${{ github.event.pull_request.head.sha }}
 `--reporter-debug` | (Optional : Default `false`) Reporter debug mode
 `--suppress-exit-code` | (Optional) Ensure that asynchronous github API is called before reporter termination.
+`--reporter-showOnlyFails` | (Optional) Only report fails.
 
 ---
 

--- a/lib/pullrequest-decorator-reporter.js
+++ b/lib/pullrequest-decorator-reporter.js
@@ -27,6 +27,7 @@ const buildOptions = (reporterOptions, newmanOptions) => {
     checkName: reporterOptions.pullrequestDecoratorCheckname,
     token: reporterOptions.pullrequestDecoratorToken,
     export: reporterOptions.export,
+    showOnlyFails: reporterOptions.showOnlyFails,
     collectionName: newmanOptions.collection.name,
     debug: reporterOptions.debug,
   };
@@ -94,8 +95,6 @@ class PullRequestDecoratorReporter {
     } else {
       throw new Error(`[-] ERROR: Result of the request named [${item.name}] cannot be identified neither as an error nor a success.`);
     }
-
-    this.context.list.push(this.context.currentItem);
   }
 
   assertion(error, args) {
@@ -111,6 +110,9 @@ class PullRequestDecoratorReporter {
       } else {
         this.context.assertions.failed_count += 1;
       }
+    }
+    if (this.context.currentItem.test_status === 'FAIL' || !this.options.showOnlyFails) {
+      this.context.list.push(this.context.currentItem);
     }
   }
 
@@ -156,7 +158,7 @@ class PullRequestDecoratorReporter {
         };
       }
       return this.context.list.find((element) => element.id === collectionItem.id);
-    });
+    }).filter(item => item !== undefined);
   }
 }
 

--- a/lib/pullrequest-decorator-reporter.js
+++ b/lib/pullrequest-decorator-reporter.js
@@ -158,7 +158,7 @@ class PullRequestDecoratorReporter {
         };
       }
       return this.context.list.find((element) => element.id === collectionItem.id);
-    }).filter(item => item !== undefined);
+    }).filter(Boolean);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@decathlon/newman-reporter-pullrequest-decorator",
   "license": "Apache-2.0",
-  "version": "0.0.19",
+  "version": "0.0.18",
   "description": "Newman reporter allowing to decorate Github's PullRequest with postman collection results",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@decathlon/newman-reporter-pullrequest-decorator",
   "license": "Apache-2.0",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "Newman reporter allowing to decorate Github's PullRequest with postman collection results",
   "main": "index.js",
   "scripts": {

--- a/test/expectations/empty-folder-markdown.md
+++ b/test/expectations/empty-folder-markdown.md
@@ -1,0 +1,2 @@
+## SC001 - As a Customer, i want to merge an anonymous cart from another anonymous cart
+

--- a/test/github-pullrequest-reporter.test.js
+++ b/test/github-pullrequest-reporter.test.js
@@ -265,7 +265,7 @@ describe("PullRequestDecoratorReporter in report mode", function () {
 
   });
 
-  it("Given a successfull assertion *assertion* event method then context is correctly filled with request information", function () {
+  it("Given a successfull assertion *assertion* event method then context current item is added to context report list", function () {
 
     // GIVEN
 
@@ -798,7 +798,7 @@ describe("GithubPullRequestReporter in showOnlyFailsMode", function () {
     on: sinon.spy()
   };
 
-  it("Given a successfull assertion *assertion* event method then context is correctly filled with request information", function () {
+  it("Given a successfull assertion *assertion* event method then context current item is ignored", function () {
 
     // GIVEN
 
@@ -815,7 +815,7 @@ describe("GithubPullRequestReporter in showOnlyFailsMode", function () {
 
   });
 
-  it("Given an assertion in error when calling *assertion* event method then context is correctly filled with request information", function () {
+  it("Given an assertion in error when calling *assertion* event method then context current item is added to the context report list", function () {
 
     // GIVEN
 

--- a/test/github-pullrequest-reporter.test.js
+++ b/test/github-pullrequest-reporter.test.js
@@ -135,7 +135,6 @@ describe("PullRequestDecoratorReporter in report mode", function () {
     expect(pullRequestDecoratorReporter.context.currentItem.body).to.not.be.null;
     expect(pullRequestDecoratorReporter.context.currentItem.code).to.equal(200);
     expect(pullRequestDecoratorReporter.context.currentItem.test_status).to.equal("PASS");
-    expect(pullRequestDecoratorReporter.context.list).to.have.lengthOf(1);
 
   });
 
@@ -174,15 +173,12 @@ describe("PullRequestDecoratorReporter in report mode", function () {
     // THEN
     expect(pullRequestDecoratorReporter.context.currentItem.body).to.equal("TECHNICAL_ERROR");
     expect(pullRequestDecoratorReporter.context.currentItem.test_status).to.equal("FAIL");
-    expect(pullRequestDecoratorReporter.context.list).to.have.lengthOf(1);
 
   });
 
   it("Given a neither valid error or successful request when calling *request* event method then throw an error", function () {
 
     // GIVEN a invalid request : it does not contain a response
-
-
     const args = {
       "request": {
         "url": {
@@ -244,6 +240,7 @@ describe("PullRequestDecoratorReporter in report mode", function () {
     expect(pullRequestDecoratorReporter.context.currentItem.test_status).to.equal("FAIL");
     expect(pullRequestDecoratorReporter.context.currentItem.failed[0]).to.equal('Status code is 200 , AssertionError , expected response to have status code 200 but got 404');
     expect(pullRequestDecoratorReporter.context.assertions.failed_count).to.equal(1);
+    expect(pullRequestDecoratorReporter.context.list).to.have.lengthOf(1);
 
   });
 
@@ -264,6 +261,23 @@ describe("PullRequestDecoratorReporter in report mode", function () {
     expect(pullRequestDecoratorReporter.context.currentItem.test_status).to.equal("SKIP");
     expect(pullRequestDecoratorReporter.context.currentItem.skipped[0]).to.equal('Status code is 200');
     expect(pullRequestDecoratorReporter.context.assertions.skipped_count).to.equal(1);
+    expect(pullRequestDecoratorReporter.context.list).to.have.lengthOf(1);
+
+  });
+
+  it("Given a successfull assertion *assertion* event method then context is correctly filled with request information", function () {
+
+    // GIVEN
+
+    const args = {
+      "skipped": false,
+      "assertion": "Status code is 200"
+    }
+
+    // WHEN
+    const pullRequestDecoratorReporter = new PullRequestDecoratorReporter(newmanEmitter, reporterOptions, newmanOptions);
+    pullRequestDecoratorReporter.assertion(null, args);
+    expect(pullRequestDecoratorReporter.context.list).to.have.lengthOf(1);
 
   });
 
@@ -706,6 +720,7 @@ describe("PullRequestDecoratorReporter in non report mode (github mode)", functi
         checkName: undefined,
         token: 'gUoowOFHOSFjn142414',
         export: undefined,
+        showOnlyFails: undefined,
         collectionName: 'ANY_COLLECTION',
         debug: undefined
       });
@@ -766,6 +781,60 @@ describe("PullRequestDecoratorReporter in non report mode (github mode)", functi
 
     // THEN WHEN
     expect(() => new PullRequestDecoratorReporter(newmanEmitter, reporterOptions, newmanOptions)).to.throw(Error, '[-] ERROR: Github PullRequest Token is missing ! Add --reporter-pullrequest-decorator-token <token>.');
+  });
+
+});
+
+describe("GithubPullRequestReporter in showOnlyFailsMode", function () {
+
+  const reporterOptions = { export: 'anyPath', showOnlyFails: true }
+  const newmanOptions = {
+    collection: {
+      name: "ANY_COLLECTION"
+    }
+  }
+
+  let newmanEmitter = {
+    on: sinon.spy()
+  };
+
+  it("Given a successfull assertion *assertion* event method then context is correctly filled with request information", function () {
+
+    // GIVEN
+
+    const args = {
+      "skipped": false,
+      "assertion": "Status code is 200"
+    }
+
+    // WHEN
+    const pullRequestDecoratorReporter = new PullRequestDecoratorReporter(newmanEmitter, reporterOptions, newmanOptions);
+    pullRequestDecoratorReporter.assertion(null, args);
+    expect(pullRequestDecoratorReporter.context.list).to.have.lengthOf(0);
+
+
+  });
+
+  it("Given an assertion in error when calling *assertion* event method then context is correctly filled with request information", function () {
+
+    // GIVEN
+
+    const error = {
+      "test": "Status code is 200",
+      "name": "AssertionError",
+      "message": "expected response to have status code 200 but got 404"
+    }
+
+    // WHEN
+    const pullRequestDecoratorReporter = new PullRequestDecoratorReporter(newmanEmitter, reporterOptions, newmanOptions);
+    pullRequestDecoratorReporter.assertion(error);
+
+    // THEN
+
+    expect(pullRequestDecoratorReporter.context.currentItem.test_status).to.equal("FAIL");
+    expect(pullRequestDecoratorReporter.context.currentItem.failed[0]).to.equal('Status code is 200 , AssertionError , expected response to have status code 200 but got 404');
+    expect(pullRequestDecoratorReporter.context.assertions.failed_count).to.equal(1);
+
   });
 
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -201,4 +201,15 @@ describe("Markdown generation", function () {
 		]))
 			.to.throw(Error, 'Collection should contain at any level either only folders or requests.');
 	});
+
+	it("Given an empty folder level postman collection when calling buildMarkdownText then generate markdown", function () {
+		const collectionName = "SC001 - As a Customer, i want to merge an anonymous cart from another anonymous cart";
+		const report = {
+			"name": collectionName,
+			"subItems": []
+		}
+		expect(path.join(expectationsDir, 'empty-folder-markdown.md')).to.be.a.file().with.content(buildMarkdownText([report
+		]
+		));
+	});
 });


### PR DESCRIPTION
Add `--reporter-showOnlyFails` option.

It allows to only report failed tests.
It can be useful for big NRT Postman collections to report on github. (there is a size limit)